### PR TITLE
Raw identifier syntax build regression - OxCaml version

### DIFF
--- a/.depend
+++ b/.depend
@@ -462,6 +462,20 @@ parsing/docstrings.cmx : \
 parsing/docstrings.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi
+parsing/keywords.cmo : \
+    utils/misc.cmi \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmx : \
+    utils/misc.cmx \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmi : \
+    parsing/keywords_token.cmi
+parsing/keywords_token.cmi : \
+    parsing/parser.cmi \
+    parsing/location.cmi \
+    parsing/docstrings.cmi
 parsing/language_extension.cmo : \
     utils/misc.cmi \
     utils/language_extension_kernel.cmi \
@@ -477,6 +491,7 @@ parsing/lexer.cmo : \
     parsing/parser.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    parsing/keywords.cmi \
     parsing/docstrings.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
@@ -574,6 +589,7 @@ parsing/pprintast.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    parsing/keywords.cmi \
     parsing/language_extension.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
@@ -583,6 +599,7 @@ parsing/pprintast.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    parsing/keywords.cmx \
     parsing/language_extension.cmx \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
@@ -1139,12 +1156,14 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
+    parsing/keywords.cmi \
     typing/jkind.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
+    parsing/keywords.cmx \
     typing/jkind.cmx \
     parsing/asttypes.cmi \
     typing/oprint.cmi
@@ -1205,9 +1224,11 @@ typing/parmatch.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
+    parsing/keywords.cmi \
     typing/ident.cmi \
     typing/path.cmi
 typing/path.cmx : \
+    parsing/keywords.cmx \
     typing/ident.cmx \
     typing/path.cmi
 typing/path.cmi : \

--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,7 @@ ocaml/primitives.new
 /otherlibs/dynlink/dynlink_compilerlibs/.depend
 /otherlibs/unix/unix.ml
 
+/parsing/keywords_token.mli
 /parsing/parser.ml
 /parsing/parser.mli
 /parsing/lexer.ml

--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -97,6 +97,7 @@ parsing_SOURCES = $(addprefix parsing/, \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mly \
+  keywords_token.mli keywords.mli keywords.ml \
   lexer.mll \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \
@@ -1753,10 +1754,22 @@ endif
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 parsing/parser.mli: boot/menhir/parser.mli
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
+# The Keywords_token module is needed as an unfortunate indirection between
+# Keywords and Parser. It simply duplicates Parser.token but since it is in an
+# .mli-only module, doesn't cause a dependency between keywords.cmx and
+# parser.cmx.
+parsing/keywords_token.mli: boot/menhir/parser.mli
+	$(V_GEN){ \
+	  echo 'type token = Parser.token ='; \
+	  grep '^  |' boot/menhir/parser.mli; } > $@
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \
-  parsing/parser.ml parsing/parser.mli
+  parsing/parser.ml parsing/parser.mli \
+  parsing/keywords_token.mli
+
+partialclean::
+	rm -f parsing/keywords_token.mli
 
 partialclean:: partialclean-menhir
 
@@ -2282,6 +2295,7 @@ ocamlprof_SOURCES = \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mli parser.ml \
+  keywords_token.mli keywords.mli keywords.ml \
   lexer.mli lexer.ml \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \

--- a/dune
+++ b/dune
@@ -69,6 +69,11 @@
 
 (copy_files# printer/*.ml{,i})
 
+(rule
+  (with-stdout-to keywords_token.mli
+    (progn (echo "type token = Parser.token =")
+           (run tools/scrape_token.exe %{dep:parser.mli}))))
+
 (menhir
  (modules parser)
  (flags
@@ -123,6 +128,7 @@
   asttypes
   cmo_format
   cmj_format
+  keywords_token
   outcometree
   parsetree
   debug_event
@@ -177,6 +183,8 @@
   camlinternalMenhirLib
   ast_iterator
   parser
+  keywords_token
+  keywords
   lexer
   parse
   pprintast

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -118,6 +118,7 @@ COMPILERLIBS_SOURCES=\
   parsing/ast_mapper.ml \
   parsing/camlinternalMenhirLib.ml \
   parsing/parser.ml \
+  parsing/keywords.ml \
   parsing/lexer.ml \
   parsing/pprintast.ml \
   typing/solver.ml \

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -94,6 +94,8 @@
   location
   longident
   docstrings
+  keywords_token
+  keywords
   lexer
   camlinternalMenhirLib
   parser_types
@@ -166,6 +168,7 @@
   asttypes
   parsetree
   outcometree
+  keywords_token
   cmo_format
   cmxs_format
   debug_event
@@ -244,6 +247,8 @@
 (copy_files ../../parsing/longident.ml)
 
 (copy_files ../../parsing/docstrings.ml)
+
+(copy_files ../../parsing/keywords.ml)
 
 (copy_files ../../parsing/lexer.ml)
 
@@ -406,6 +411,10 @@
 (copy_files ../../parsing/longident.mli)
 
 (copy_files ../../parsing/docstrings.mli)
+
+(copy_files ../../keywords_token.mli)
+
+(copy_files ../../parsing/keywords.mli)
 
 (copy_files ../../parsing/lexer.mli)
 
@@ -596,6 +605,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Linkage_name.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Symbol.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Docstrings.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Keywords.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lexer.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Path.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Printast.cmo
@@ -695,6 +705,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Linkage_name.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Symbol.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Docstrings.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Keywords.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lexer.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Path.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lazy_backtrack.cmx

--- a/parsing/keywords.ml
+++ b/parsing/keywords.ml
@@ -1,0 +1,100 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The table of keywords *)
+
+open Keywords_token
+
+let keyword_table =
+  Misc.create_hashtable 149 [
+    "and", AND;
+    "as", AS;
+    "assert", ASSERT;
+    "begin", BEGIN;
+    "class", CLASS;
+    "constraint", CONSTRAINT;
+    "do", DO;
+    "done", DONE;
+    "downto", DOWNTO;
+    "else", ELSE;
+    "end", END;
+    "exception", EXCEPTION;
+    "exclave_", EXCLAVE;
+    "external", EXTERNAL;
+    "false", FALSE;
+    "for", FOR;
+    "fun", FUN;
+    "function", FUNCTION;
+    "functor", FUNCTOR;
+    "global_", GLOBAL;
+    "if", IF;
+    "in", IN;
+    "include", INCLUDE;
+    "inherit", INHERIT;
+    "initializer", INITIALIZER;
+    "kind_abbrev_", KIND_ABBREV;
+    "kind_of_", KIND_OF;
+    "lazy", LAZY;
+    "let", LET;
+    "local_", LOCAL;
+    "match", MATCH;
+    "method", METHOD;
+    "mod", MOD;
+    "module", MODULE;
+    "mutable", MUTABLE;
+    "new", NEW;
+    "nonrec", NONREC;
+    "object", OBJECT;
+    "of", OF;
+    "once_", ONCE;
+    "open", OPEN;
+    "or", OR;
+    "overwrite_", OVERWRITE;
+(*  "parser", PARSER; *)
+    "private", PRIVATE;
+    "rec", REC;
+    "sig", SIG;
+    "stack_", STACK;
+    "struct", STRUCT;
+    "then", THEN;
+    "to", TO;
+    "true", TRUE;
+    "try", TRY;
+    "type", TYPE;
+    "unique_", UNIQUE;
+    "val", VAL;
+    "virtual", VIRTUAL;
+    "when", WHEN;
+    "while", WHILE;
+    "with", WITH;
+
+    "lor", INFIXOP3("lor"); (* Should be INFIXOP2 *)
+    "lxor", INFIXOP3("lxor"); (* Should be INFIXOP2 *)
+    "land", INFIXOP3("land");
+    "lsl", INFIXOP4("lsl");
+    "lsr", INFIXOP4("lsr");
+    "asr", INFIXOP4("asr")
+]
+
+let lookup_keyword name =
+  match Hashtbl.find keyword_table name with
+  | kw -> kw
+  | exception Not_found ->
+     LIDENT name
+
+let is_keyword name =
+  match lookup_keyword name with
+  | LIDENT _ -> false
+  | _ -> true

--- a/parsing/keywords.mli
+++ b/parsing/keywords.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val is_keyword : string -> bool
+
+val lookup_keyword : string -> Keywords_token.token

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -41,8 +41,6 @@ exception Error of error * Location.t
 val in_comment : unit -> bool
 val in_string : unit -> bool
 
-val is_keyword : string -> bool
-
 val print_warnings : bool ref
 val handle_docstrings : bool ref
 val comments : unit -> (string * Location.t) list

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -99,7 +99,7 @@ let needs_spaces txt =
   operator. *)
 let ident_of_name ppf txt =
   let format : (_, _, _) format =
-    if Lexer.is_keyword txt then "\\#%s"
+    if Keywords.is_keyword txt then "\\#%s"
     else if not (needs_parens txt) then "%s"
     else if needs_spaces txt then "(@;%s@;)"
     else "(%s)"
@@ -301,7 +301,7 @@ let tyvar_of_name s =
     (* without the space, this would be parsed as
        a character literal *)
     "' " ^ s
-  else if Lexer.is_keyword s then
+  else if Keywords.is_keyword s then
     "'\\#" ^ s
   else if String.equal s "_" then
     s

--- a/tools/dune
+++ b/tools/dune
@@ -162,3 +162,7 @@
  (name gen_compiler_libs_installation)
  (modes native)
  (modules gen_compiler_libs_installation))
+
+(executable
+  (name scrape_token)
+  (modules scrape_token))

--- a/tools/scrape_token.ml
+++ b/tools/scrape_token.ml
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*            David Allsopp, University of Cambridge & Tarides            *)
+(*                                                                        *)
+(*   Copyright 2025 David Allsopp Ltd.                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+let () =
+  try
+    In_channel.with_open_text Sys.argv.(1) (fun ic ->
+      while true do
+        let line = input_line ic in
+        if String.starts_with ~prefix:"  |" line then
+          print_endline line
+      done
+    )
+  with End_of_file -> ()

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -24,7 +24,7 @@ let cautious f ppf arg =
 
 let print_lident ppf = function
   | "::" -> pp_print_string ppf "(::)"
-  | s when Lexer.is_keyword s -> fprintf ppf "\\#%s" s
+  | s when Keywords.is_keyword s -> fprintf ppf "\\#%s" s
   | s -> pp_print_string ppf s
 
 let rec print_ident ppf =
@@ -65,7 +65,7 @@ let parenthesized_ident name =
 let value_ident ppf name =
   if parenthesized_ident name then
     fprintf ppf "( %s )" name
-  else if Lexer.is_keyword name then
+  else if Keywords.is_keyword name then
     fprintf ppf "\\#%s" name
   else
     pp_print_string ppf name

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -117,7 +117,7 @@ let rec scope = function
 let kfalse _ = false
 
 let maybe_escape s =
-  if Lexer.is_keyword s then "\\#" ^ s else s
+  if Keywords.is_keyword s then "\\#" ^ s else s
 
 let rec name ?(paren=kfalse) = function
     Pident id -> maybe_escape (Ident.name id)


### PR DESCRIPTION
```console
$ hyperfine -p 'git clean -dfX; git checkout {sha}; autoconf; ./configure --enable-runtime5' -L sha 333fd56df5,b600510816 'make -j compiler'
Benchmark 1: make -j compiler (sha = 333fd56df5)
  Time (mean ± σ):     243.549 s ±  3.419 s    [User: 1451.339 s, System: 199.673 s]
  Range (min … max):   240.587 s … 252.889 s    10 runs

Benchmark 2: make -j compiler (sha = b600510816)
  Time (mean ± σ):     226.863 s ±  1.975 s    [User: 1380.569 s, System: 191.866 s]
  Range (min … max):   224.205 s … 230.289 s    10 runs
```